### PR TITLE
notesテーブルの修正

### DIFF
--- a/backend/app/adapter/dao/music_sheets.go
+++ b/backend/app/adapter/dao/music_sheets.go
@@ -555,7 +555,7 @@ func (o *MusicSheet) AddNotes(ctx context.Context, exec boil.ContextExecutor, in
 				strmangle.SetParamNames("\"", "\"", 1, []string{"music_sheet_id"}),
 				strmangle.WhereClause("\"", "\"", 2, notePrimaryKeyColumns),
 			)
-			values := []interface{}{o.MusicSheetID, rel.NoteID}
+			values := []interface{}{o.MusicSheetID, rel.Index, rel.MusicSheetID}
 
 			if boil.IsDebug(ctx) {
 				writer := boil.DebugWriterFrom(ctx)

--- a/backend/schema/db/ddl.sql
+++ b/backend/schema/db/ddl.sql
@@ -20,9 +20,10 @@ CREATE TABLE "music_sheets"
 -- notes テーブルを作成
 CREATE TABLE "notes"
 (
-    "note_id"        UUID PRIMARY KEY,
+    "index"          INT NOT NULL,
     "music_sheet_id" UUID NOT NULL REFERENCES "music_sheets"("music_sheet_id") ON DELETE CASCADE,
     "pitches"        INT[] NOT NULL,
     "created_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "updated_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("index", "music_sheet_id")
 );


### PR DESCRIPTION
## これはなに

- notes DBの設計を修正したもの
- indexを追加して、何番目に流れるのか(?)を指定できるようにした
- make `db-migrate`の結果

```
-- Apply --
ALTER TABLE "public"."notes" ADD COLUMN "index" integer NOT NULL;
ALTER TABLE "public"."notes" DROP CONSTRAINT "notes_pkey";
ALTER TABLE "public"."notes" ADD PRIMARY KEY ("index", "music_sheet_id");
ALTER TABLE "public"."notes" DROP CONSTRAINT "notes_music_sheet_id_fkey";
ALTER TABLE "public"."notes" ADD CONSTRAINT "notes_music_sheet_id_fkey" FOREIGN KEY ("music_sheet_id") REFERENCES "public"."music_sheets" ("music_sheet_id") ON DELETE CASCADE;
ALTER TABLE "public"."notes" DROP COLUMN "note_id";
```