### PR TITLE
feature: noteテーブルにindexカラム追加

### DIFF
--- a/backend/app/adapter/dao/music_sheets.go
+++ b/backend/app/adapter/dao/music_sheets.go
@@ -555,7 +555,7 @@ func (o *MusicSheet) AddNotes(ctx context.Context, exec boil.ContextExecutor, in
 				strmangle.SetParamNames("\"", "\"", 1, []string{"music_sheet_id"}),
 				strmangle.WhereClause("\"", "\"", 2, notePrimaryKeyColumns),
 			)
-			values := []interface{}{o.MusicSheetID, rel.NoteID}
+			values := []interface{}{o.MusicSheetID, rel.Index, rel.MusicSheetID}
 
 			if boil.IsDebug(ctx) {
 				writer := boil.DebugWriterFrom(ctx)

--- a/backend/app/adapter/dao/notes.go
+++ b/backend/app/adapter/dao/notes.go
@@ -24,7 +24,7 @@ import (
 
 // Note is an object representing the database table.
 type Note struct {
-	NoteID       string           `boil:"note_id" json:"note_id" toml:"note_id" yaml:"note_id"`
+	Index        int              `boil:"index" json:"index" toml:"index" yaml:"index"`
 	MusicSheetID string           `boil:"music_sheet_id" json:"music_sheet_id" toml:"music_sheet_id" yaml:"music_sheet_id"`
 	Pitches      types.Int64Array `boil:"pitches" json:"pitches" toml:"pitches" yaml:"pitches"`
 	CreatedAt    time.Time        `boil:"created_at" json:"created_at" toml:"created_at" yaml:"created_at"`
@@ -35,13 +35,13 @@ type Note struct {
 }
 
 var NoteColumns = struct {
-	NoteID       string
+	Index        string
 	MusicSheetID string
 	Pitches      string
 	CreatedAt    string
 	UpdatedAt    string
 }{
-	NoteID:       "note_id",
+	Index:        "index",
 	MusicSheetID: "music_sheet_id",
 	Pitches:      "pitches",
 	CreatedAt:    "created_at",
@@ -49,13 +49,13 @@ var NoteColumns = struct {
 }
 
 var NoteTableColumns = struct {
-	NoteID       string
+	Index        string
 	MusicSheetID string
 	Pitches      string
 	CreatedAt    string
 	UpdatedAt    string
 }{
-	NoteID:       "notes.note_id",
+	Index:        "notes.index",
 	MusicSheetID: "notes.music_sheet_id",
 	Pitches:      "notes.pitches",
 	CreatedAt:    "notes.created_at",
@@ -63,6 +63,29 @@ var NoteTableColumns = struct {
 }
 
 // Generated where
+
+type whereHelperint struct{ field string }
+
+func (w whereHelperint) EQ(x int) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.EQ, x) }
+func (w whereHelperint) NEQ(x int) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.NEQ, x) }
+func (w whereHelperint) LT(x int) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.LT, x) }
+func (w whereHelperint) LTE(x int) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
+func (w whereHelperint) GT(x int) qm.QueryMod  { return qmhelper.Where(w.field, qmhelper.GT, x) }
+func (w whereHelperint) GTE(x int) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
+func (w whereHelperint) IN(slice []int) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
+}
+func (w whereHelperint) NIN(slice []int) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
+}
 
 type whereHelpertypes_Int64Array struct{ field string }
 
@@ -86,13 +109,13 @@ func (w whereHelpertypes_Int64Array) GTE(x types.Int64Array) qm.QueryMod {
 }
 
 var NoteWhere = struct {
-	NoteID       whereHelperstring
+	Index        whereHelperint
 	MusicSheetID whereHelperstring
 	Pitches      whereHelpertypes_Int64Array
 	CreatedAt    whereHelpertime_Time
 	UpdatedAt    whereHelpertime_Time
 }{
-	NoteID:       whereHelperstring{field: "\"notes\".\"note_id\""},
+	Index:        whereHelperint{field: "\"notes\".\"index\""},
 	MusicSheetID: whereHelperstring{field: "\"notes\".\"music_sheet_id\""},
 	Pitches:      whereHelpertypes_Int64Array{field: "\"notes\".\"pitches\""},
 	CreatedAt:    whereHelpertime_Time{field: "\"notes\".\"created_at\""},
@@ -127,10 +150,10 @@ func (r *noteR) GetMusicSheet() *MusicSheet {
 type noteL struct{}
 
 var (
-	noteAllColumns            = []string{"note_id", "music_sheet_id", "pitches", "created_at", "updated_at"}
-	noteColumnsWithoutDefault = []string{"note_id", "music_sheet_id", "pitches"}
+	noteAllColumns            = []string{"index", "music_sheet_id", "pitches", "created_at", "updated_at"}
+	noteColumnsWithoutDefault = []string{"index", "music_sheet_id", "pitches"}
 	noteColumnsWithDefault    = []string{"created_at", "updated_at"}
-	notePrimaryKeyColumns     = []string{"note_id"}
+	notePrimaryKeyColumns     = []string{"index", "music_sheet_id"}
 	noteGeneratedColumns      = []string{}
 )
 
@@ -586,7 +609,7 @@ func (o *Note) SetMusicSheet(ctx context.Context, exec boil.ContextExecutor, ins
 		strmangle.SetParamNames("\"", "\"", 1, []string{"music_sheet_id"}),
 		strmangle.WhereClause("\"", "\"", 2, notePrimaryKeyColumns),
 	)
-	values := []interface{}{related.MusicSheetID, o.NoteID}
+	values := []interface{}{related.MusicSheetID, o.Index, o.MusicSheetID}
 
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
@@ -630,7 +653,7 @@ func Notes(mods ...qm.QueryMod) noteQuery {
 
 // FindNote retrieves a single record by ID with an executor.
 // If selectCols is empty Find will return all columns.
-func FindNote(ctx context.Context, exec boil.ContextExecutor, noteID string, selectCols ...string) (*Note, error) {
+func FindNote(ctx context.Context, exec boil.ContextExecutor, index int, musicSheetID string, selectCols ...string) (*Note, error) {
 	noteObj := &Note{}
 
 	sel := "*"
@@ -638,10 +661,10 @@ func FindNote(ctx context.Context, exec boil.ContextExecutor, noteID string, sel
 		sel = strings.Join(strmangle.IdentQuoteSlice(dialect.LQ, dialect.RQ, selectCols), ",")
 	}
 	query := fmt.Sprintf(
-		"select %s from \"notes\" where \"note_id\"=$1", sel,
+		"select %s from \"notes\" where \"index\"=$1 AND \"music_sheet_id\"=$2", sel,
 	)
 
-	q := queries.Raw(query, noteID)
+	q := queries.Raw(query, index, musicSheetID)
 
 	err := q.Bind(ctx, exec, noteObj)
 	if err != nil {
@@ -1023,7 +1046,7 @@ func (o *Note) Delete(ctx context.Context, exec boil.ContextExecutor) (int64, er
 	}
 
 	args := queries.ValuesFromMapping(reflect.Indirect(reflect.ValueOf(o)), notePrimaryKeyMapping)
-	sql := "DELETE FROM \"notes\" WHERE \"note_id\"=$1"
+	sql := "DELETE FROM \"notes\" WHERE \"index\"=$1 AND \"music_sheet_id\"=$2"
 
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
@@ -1120,7 +1143,7 @@ func (o NoteSlice) DeleteAll(ctx context.Context, exec boil.ContextExecutor) (in
 // Reload refetches the object from the database
 // using the primary keys with an executor.
 func (o *Note) Reload(ctx context.Context, exec boil.ContextExecutor) error {
-	ret, err := FindNote(ctx, exec, o.NoteID)
+	ret, err := FindNote(ctx, exec, o.Index, o.MusicSheetID)
 	if err != nil {
 		return err
 	}
@@ -1159,16 +1182,16 @@ func (o *NoteSlice) ReloadAll(ctx context.Context, exec boil.ContextExecutor) er
 }
 
 // NoteExists checks if the Note row exists.
-func NoteExists(ctx context.Context, exec boil.ContextExecutor, noteID string) (bool, error) {
+func NoteExists(ctx context.Context, exec boil.ContextExecutor, index int, musicSheetID string) (bool, error) {
 	var exists bool
-	sql := "select exists(select 1 from \"notes\" where \"note_id\"=$1 limit 1)"
+	sql := "select exists(select 1 from \"notes\" where \"index\"=$1 AND \"music_sheet_id\"=$2 limit 1)"
 
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
 		fmt.Fprintln(writer, sql)
-		fmt.Fprintln(writer, noteID)
+		fmt.Fprintln(writer, index, musicSheetID)
 	}
-	row := exec.QueryRowContext(ctx, sql, noteID)
+	row := exec.QueryRowContext(ctx, sql, index, musicSheetID)
 
 	err := row.Scan(&exists)
 	if err != nil {
@@ -1180,7 +1203,7 @@ func NoteExists(ctx context.Context, exec boil.ContextExecutor, noteID string) (
 
 // Exists checks if the Note row exists.
 func (o *Note) Exists(ctx context.Context, exec boil.ContextExecutor) (bool, error) {
-	return NoteExists(ctx, exec, o.NoteID)
+	return NoteExists(ctx, exec, o.Index, o.MusicSheetID)
 }
 
 // /////////////////////////////// BEGIN EXTENSIONS /////////////////////////////////

--- a/backend/schema/db/ddl.sql
+++ b/backend/schema/db/ddl.sql
@@ -20,9 +20,10 @@ CREATE TABLE "music_sheets"
 -- notes テーブルを作成
 CREATE TABLE "notes"
 (
-    "note_id"        UUID PRIMARY KEY,
+    "index"          INT NOT NULL,
     "music_sheet_id" UUID NOT NULL REFERENCES "music_sheets"("music_sheet_id") ON DELETE CASCADE,
     "pitches"        INT[] NOT NULL,
     "created_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "updated_at"     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("index", "music_sheet_id")
 );


### PR DESCRIPTION
## これはなに

- notes DBの設計を修正したもの
- indexを追加して、何番目に流れるのか(?)を指定できるようにした
- make `db-migrate`の結果

```
-- Apply --
ALTER TABLE "public"."notes" ADD COLUMN "index" integer NOT NULL;
ALTER TABLE "public"."notes" DROP CONSTRAINT "notes_pkey";
ALTER TABLE "public"."notes" ADD PRIMARY KEY ("index", "music_sheet_id");
ALTER TABLE "public"."notes" DROP CONSTRAINT "notes_music_sheet_id_fkey";
ALTER TABLE "public"."notes" ADD CONSTRAINT "notes_music_sheet_id_fkey" FOREIGN KEY ("music_sheet_id") REFERENCES "public"."music_sheets" ("music_sheet_id") ON DELETE CASCADE;
ALTER TABLE "public"."notes" DROP COLUMN "note_id";
```